### PR TITLE
Add /r/:name endpoint to cjhbot

### DIFF
--- a/derpy.rb
+++ b/derpy.rb
@@ -40,6 +40,21 @@ get '/test' do
   channel.post(message)
 end
 
+get '/r/:name' do
+  url  = "https://www.reddit.com/r/#{params[:name]}"
+  data = JSON.parse Faraday.get("#{url}/about/.json").body
+  if data['error'].nil?
+    message = OutgoingMessage.new(
+      channel:  slack_channel,
+      username: '/r/cjh',
+      icon_url: 'http://i.imgur.com/w5yXDIe.jpg',
+      text: "#{data['display_name']}: #{url}"
+    )
+
+    channel.post(message)
+  end
+end
+
 get '/cjh' do
   response = Cjh.call(params[:text])
 


### PR DESCRIPTION
Haven't added an endpoint yet and don't know how to test. Took a stab at it, no idea if this is right.

Basically want to be able to type /r/videos and have cjhbot respond with

```
videos: https://www.reddit.com/r/videos
```

![golden-retriever](https://cloud.githubusercontent.com/assets/50568/8887538/a6188dfa-323b-11e5-8766-24e7531b7222.jpg)

@jerhinesmith 
